### PR TITLE
Added option for APLA-Reprompt and updated APLA Version to 9

### DIFF
--- a/src/Response/AlexaResponse.php
+++ b/src/Response/AlexaResponse.php
@@ -183,7 +183,7 @@ class AlexaResponse implements AlexaResponseInterface
         }
         if ($this->aplaReprompt) {
             $response['reprompt'] = [
-                'directives' => $this->aplaReprompt->toArray()
+                'directives' => [$this->aplaReprompt->toArray()]
             ];
         }
 

--- a/src/Response/AlexaResponse.php
+++ b/src/Response/AlexaResponse.php
@@ -52,6 +52,9 @@ class AlexaResponse implements AlexaResponseInterface
     /** @var bool  */
     private $undefinedEndSession = false;
 
+    /** @var DirectivesInterface */
+    private $aplaReprompt;
+
     /**
      * Add a directive
      *
@@ -116,6 +119,16 @@ class AlexaResponse implements AlexaResponseInterface
         $this->undefinedEndSession = true;
     }
 
+    /**
+     * Add a reprompt with APLA
+     *
+     * @param DirectivesInterface $aplaReprompt
+     */
+    public function addAplaReprompt(DirectivesInterface $aplaReprompt)
+    {
+        $this->aplaReprompt = $aplaReprompt;
+    }
+
 
 
     /**
@@ -166,6 +179,11 @@ class AlexaResponse implements AlexaResponseInterface
         if ($this->reprompt) {
             $response['reprompt'] = [
                 'outputSpeech' => $this->reprompt->toArray()
+            ];
+        }
+        if ($this->aplaReprompt) {
+            $response['reprompt'] = [
+                'directives' => $this->aplaReprompt->toArray()
             ];
         }
 

--- a/src/Response/Directives/Alexa/Presentation/APLA/Document/APLA.php
+++ b/src/Response/Directives/Alexa/Presentation/APLA/Document/APLA.php
@@ -26,13 +26,10 @@ class APLA implements DirectivesInterface
     public const DIRECTIVE_TYPE = 'APLA';
 
     /** @var string */
-    private $version = '0.91';
+    private $version = '0.9';
 
     /** @var array */
     private $mainTemplate = [];
-
-    /** @var array */
-    private $resources = [];
 
     /**
      * APLA constructor.
@@ -40,10 +37,8 @@ class APLA implements DirectivesInterface
      * @param array $mainTemplate
      */
     public function __construct(
-        array $resources,
         array $mainTemplate
     ) {
-        $this->resources = $resources;
         $this->mainTemplate = $mainTemplate;
     }
 
@@ -57,9 +52,8 @@ class APLA implements DirectivesInterface
         $aplaData = json_decode($aplaJson, true);
 
         $mainTemplate = $aplaData['mainTemplate'] ?? [];
-        $resources = $aplaData['resources'] ?? [];
 
-        return new APLA($resources, $mainTemplate);
+        return new APLA($mainTemplate);
     }
 
     /**
@@ -90,7 +84,6 @@ class APLA implements DirectivesInterface
         $data = [
             'type'         => $this->getType(),
             'version'      => $this->version,
-            'resources'    => $this->resources,
             'mainTemplate' => $this->mainTemplate,
         ];
 


### PR DESCRIPTION
usage: 

```
$aplaRepromptDocument = APLA::createFromFile($this->getSkillConfiguration()->getAplDocuments()['reprompt_apla']);
        $repromptData = [
            'speechData' =>
                             [
                                 'reprompt' => $repromptMessage,
                                 'sound'    => $host . $this->getTextHelper()->getSound('SFX_BACK')
                             ]
        ];
        $repromptDocument = new APLARenderDocument($aplaRepromptDocument, 'reprompt', $repromptData);
        $this->getAlexaResponse()->addAplaReprompt($repromptDocument);
```