### PR TITLE
Update SessionEndedIntent.php

### DIFF
--- a/src/Intent/SessionEndedIntent.php
+++ b/src/Intent/SessionEndedIntent.php
@@ -20,7 +20,7 @@ class SessionEndedIntent extends AbstractIntent
         $reason = $this->getAlexaRequest()->getRequest()->getReason();
         $error  = $this->getAlexaRequest()->getRequest()->getError();
 
-        if ($reason != "USER_INITIATED") {
+        if ($reason == "ERROR") {
             if ($this->isErrorLogFlag() == true) {
                 $microtime = explode('.', (string)microtime(true));
 


### PR DESCRIPTION
Changed Reason explicit to "ERROR", because new Types of SessionEndedRequests are invented, that don't send Error-Information 